### PR TITLE
Add iron-vm host configuration for VM testing

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,48 @@
             }
           ];
         };
+        
+        # VM configuration for testing
+        iron-vm = nixpkgs.lib.nixosSystem {
+          inherit system;
+          specialArgs = { inherit inputs; };
+          modules = [
+            # Core system configuration
+            ./configuration.nix
+            
+            # Host-specific configuration
+            ./hosts/iron-vm/configuration.nix
+            ./hosts/iron-vm/hardware-configuration.nix
+            
+            # Stylix for system-wide theming
+            stylix.nixosModules.stylix
+            
+            # System modules
+            ./modules/bootloader.nix
+            ./modules/users.nix
+            ./modules/system.nix
+            
+            # Feature modules
+            ./modules/gaming.nix
+            ./modules/development.nix
+            ./modules/productivity.nix
+            ./modules/hyprland.nix
+            ./modules/security.nix
+            ./modules/performance.nix
+            ./modules/stylix.nix
+            ./modules/shells.nix
+            ./modules/neovim.nix
+            
+            # Home Manager
+            home-manager.nixosModules.home-manager
+            {
+              home-manager.useGlobalPkgs = true;
+              home-manager.useUserPackages = true;
+              home-manager.extraSpecialArgs = { inherit inputs; };
+              home-manager.users.derrick = import ./home/home.nix;
+            }
+          ];
+        };
       };
 
       # Development shells for various languages

--- a/hosts/iron-vm/README.md
+++ b/hosts/iron-vm/README.md
@@ -76,7 +76,17 @@ This configuration is optimized for testing your NixOS config in a virtual machi
    - Set Network to NAT or Bridged
    - Enable clipboard sharing
 
-3. Note: You may need to adjust `virtualisation.virtualbox.guest.enable = true` in configuration.nix
+3. **Important for VirtualBox users**: You must enable VirtualBox guest additions.
+   Edit `hosts/iron-vm/configuration.nix` and change line 16:
+   ```nix
+   # Change from:
+   virtualisation.virtualbox.guest.enable = lib.mkDefault false;
+   # To:
+   virtualisation.virtualbox.guest.enable = true;
+   ```
+   This enables proper guest integration, clipboard sharing, and display resolution adjustments.
+
+4. Follow the same installation steps as Option 1
 
 ## Building the Configuration
 

--- a/hosts/iron-vm/README.md
+++ b/hosts/iron-vm/README.md
@@ -1,0 +1,162 @@
+# Iron-VM - Virtual Machine Configuration
+
+This configuration is optimized for testing your NixOS config in a virtual machine before deploying to bare metal.
+
+## VM Optimizations Included
+
+- **Virtio Drivers**: For better disk, network, and I/O performance
+- **QEMU Guest Agent**: Better integration with QEMU/KVM hypervisors
+- **VMware Tools**: Support for VMware Workstation/Fusion
+- **ZRAM**: Compressed swap in RAM for better memory usage
+- **Fast Boot**: Reduced boot timeout (1 second)
+- **Serial Console**: For debugging and rescue scenarios
+- **SSH Enabled**: Easy remote access (with password authentication for testing)
+- **Clipboard Sharing**: Via SPICE agent
+
+## Creating the VM
+
+### Option 1: Using virt-manager (QEMU/KVM)
+
+1. Download the latest NixOS ISO from https://nixos.org/download.html
+2. Create a new VM in virt-manager:
+   - **OS**: Linux, NixOS (or Generic Linux)
+   - **Memory**: 4GB minimum (8GB recommended)
+   - **CPU**: 2 cores minimum (4 recommended)
+   - **Disk**: 40GB minimum
+   - **Network**: NAT or Bridge mode
+   - **Display**: SPICE or VNC
+   - **Video**: VirtIO or QXL
+
+3. During installation:
+   ```bash
+   # Set up your partitions
+   sudo fdisk /dev/vda  # or /dev/sda
+   
+   # Format and mount
+   sudo mkfs.ext4 /dev/vda1
+   sudo mount /dev/vda1 /mnt
+   
+   # Generate initial config
+   sudo nixos-generate-config --root /mnt
+   
+   # Clone your config repo
+   nix-shell -p git
+   git clone https://github.com/iron-tower-dev/nixos-config /mnt/etc/nixos/nixos-config
+   
+   # Copy the generated hardware-configuration.nix
+   sudo cp /mnt/etc/nixos/hardware-configuration.nix /mnt/etc/nixos/nixos-config/hosts/iron-vm/
+   
+   # Install
+   sudo nixos-install --flake /mnt/etc/nixos/nixos-config#iron-vm
+   ```
+
+### Option 2: Using VMware Workstation/Fusion
+
+1. Create a new VM:
+   - **Guest OS**: Linux, Other Linux 5.x kernel 64-bit
+   - **Memory**: 4GB minimum (8GB recommended)
+   - **CPU**: 2 cores minimum
+   - **Disk**: 40GB (can be thin-provisioned)
+   - **Network**: NAT or Bridged
+
+2. Enable 3D acceleration in VM settings
+3. Follow the same installation steps as Option 1
+
+### Option 3: Using VirtualBox
+
+1. Create a new VM:
+   - **Type**: Linux
+   - **Version**: Linux 2.6 / 3.x / 4.x / 5.x (64-bit)
+   - **Memory**: 4GB minimum
+   - **CPU**: 2 cores minimum
+   - **Disk**: 40GB VDI
+
+2. In Settings:
+   - Enable 3D Acceleration
+   - Set Network to NAT or Bridged
+   - Enable clipboard sharing
+
+3. Note: You may need to adjust `virtualisation.virtualbox.guest.enable = true` in configuration.nix
+
+## Building the Configuration
+
+After installation, to test configuration changes:
+
+```bash
+# Build the configuration
+sudo nixos-rebuild build --flake /etc/nixos/nixos-config#iron-vm
+
+# Or build from your host machine (outside VM)
+nix build .#nixosConfigurations.iron-vm.config.system.build.toplevel
+
+# Apply changes in the VM
+sudo nixos-rebuild switch --flake /etc/nixos/nixos-config#iron-vm
+```
+
+## Testing Workflow
+
+1. **Make changes** to your config on the host machine
+2. **Push changes** to git (or use shared folder)
+3. **Pull changes** in the VM
+4. **Rebuild and test** in the VM
+5. **If successful**, deploy to bare metal
+
+## Performance Tips
+
+- Allocate enough RAM (8GB recommended for full desktop experience)
+- Use VirtIO drivers for best performance
+- Enable 3D acceleration in VM settings
+- Consider using host passthrough CPU mode for better performance
+- For QEMU/KVM, use `cache=writeback` for better disk performance
+
+## Optional: Auto-login for Testing
+
+To enable automatic login (makes testing faster, but less secure):
+
+Uncomment in `configuration.nix`:
+```nix
+services.displayManager.autoLogin = {
+  enable = true;
+  user = "derrick";
+};
+```
+
+## Shared Folders (Optional)
+
+For easier config syncing, you can set up shared folders:
+
+### QEMU/KVM (9p)
+```nix
+fileSystems."/mnt/shared" = {
+  device = "shared";
+  fsType = "9p";
+  options = [ "trans=virtio" "version=9p2000.L" ];
+};
+```
+
+### VMware
+Enable shared folders in VM settings, then they'll be available via vmware-hgfsclient
+
+### VirtualBox
+Enable shared folders in VM settings and use vboxsf filesystem
+
+## Troubleshooting
+
+- **Slow graphics**: Ensure 3D acceleration is enabled and correct video drivers are loaded
+- **No network**: Check that virtio_net module is loaded (`lsmod | grep virtio`)
+- **Boot issues**: Use the serial console to debug (appears in VM logs)
+- **Build failures**: Check the flake.lock is up to date with `nix flake update`
+
+## SSH Access
+
+SSH is enabled by default in the VM for easy access:
+
+```bash
+# From host machine
+ssh derrick@<vm-ip>
+```
+
+To find the VM IP:
+```bash
+ip addr show
+```

--- a/hosts/iron-vm/configuration.nix
+++ b/hosts/iron-vm/configuration.nix
@@ -1,0 +1,122 @@
+{ config, pkgs, lib, ... }:
+
+{
+  # Host-specific configuration for iron-vm (Virtual Machine for Testing)
+  
+  # Hostname
+  networking.hostName = "iron-vm";
+  
+  # Timezone
+  time.timeZone = "America/New_York";
+  
+  # VM-specific optimizations
+  
+  # Enable guest additions for better VM integration
+  virtualisation.vmware.guest.enable = lib.mkDefault true;
+  virtualisation.virtualbox.guest.enable = lib.mkDefault false;
+  
+  # QEMU/KVM guest agent for better integration
+  services.qemuGuest.enable = true;
+  services.spice-vdagentd.enable = true; # For SPICE display protocol
+  
+  # Optimize for virtual hardware
+  boot.kernelParams = [
+    "elevator=noop"  # VM disk scheduler optimization
+    "clocksource=kvm-clock"  # Better time sync in VMs
+  ];
+  
+  # Faster boot for testing
+  boot.loader.timeout = 1;
+  
+  # Disable unnecessary services for VMs to speed up boot
+  services.thermald.enable = lib.mkForce false;
+  powerManagement.enable = lib.mkDefault false;
+  
+  # Enable virtio drivers for better performance
+  boot.initrd.availableKernelModules = [ 
+    "virtio_pci" 
+    "virtio_blk" 
+    "virtio_scsi" 
+    "virtio_net"
+    "9p"
+    "9pnet_virtio"
+  ];
+  
+  # Graphics for VM (use lightweight option)
+  services.xserver.videoDrivers = lib.mkDefault [ "modesetting" ];
+  
+  # Enable 3D acceleration for VMs (works with most hypervisors)
+  hardware.opengl = {
+    enable = true;
+    driSupport = true;
+  };
+  
+  # VM-friendly file system optimizations
+  # Disable some file system features that don't work well in VMs
+  fileSystems."/".options = [ "noatime" "nodiratime" ];
+  
+  # Smaller swap for VM (can be adjusted based on allocated RAM)
+  swapDevices = lib.mkDefault [ ];
+  
+  # VM testing tools
+  environment.systemPackages = with pkgs; [
+    # VM utilities
+    open-vm-tools  # VMware tools (if using VMware)
+    
+    # Testing and debugging
+    htop
+    iotop
+    lsof
+    strace
+    
+    # Quick system checks
+    neofetch
+    inxi
+  ];
+  
+  # Enable clipboard sharing with host
+  services.spice-vdagentd.enable = true;
+  
+  # Disable gaming-specific features to save resources
+  # Note: These will still be loaded from modules, but can be overridden here
+  
+  # Optional: Reduce resource usage by disabling some features
+  # Uncomment these if the VM is too slow:
+  # services.udisks2.enable = lib.mkDefault false;
+  # services.gnome.gnome-keyring.enable = lib.mkDefault false;
+  
+  # Enable serial console for debugging
+  boot.kernelParams = [ "console=ttyS0,115200" "console=tty1" ];
+  
+  # VM memory optimization - enable ZRAM for better memory usage
+  zramSwap = {
+    enable = true;
+    algorithm = "zstd";
+    memoryPercent = 50;
+  };
+  
+  # Disable some performance-heavy features for smoother VM experience
+  # Override gaming module settings if needed
+  # programs.gamemode.enable = lib.mkForce false;
+  
+  # Network optimization for VMs
+  networking.interfaces = lib.mkDefault {
+    # VM typically uses NAT or bridged networking
+  };
+  
+  # Enable SSH for easy access to VM
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "no";
+      PasswordAuthentication = true; # For easier VM testing
+    };
+  };
+  
+  # Automatic login for testing convenience (optional - less secure)
+  # Uncomment if you want auto-login for testing:
+  # services.displayManager.autoLogin = {
+  #   enable = true;
+  #   user = "derrick";
+  # };
+}

--- a/hosts/iron-vm/configuration.nix
+++ b/hosts/iron-vm/configuration.nix
@@ -22,6 +22,8 @@
   boot.kernelParams = [
     "elevator=noop"  # VM disk scheduler optimization
     "clocksource=kvm-clock"  # Better time sync in VMs
+    "console=ttyS0,115200"  # Serial console for debugging
+    "console=tty1"  # TTY console
   ];
   
   # Faster boot for testing
@@ -83,9 +85,6 @@
   # Uncomment these if the VM is too slow:
   # services.udisks2.enable = lib.mkDefault false;
   # services.gnome.gnome-keyring.enable = lib.mkDefault false;
-  
-  # Enable serial console for debugging
-  boot.kernelParams = [ "console=ttyS0,115200" "console=tty1" ];
   
   # VM memory optimization - enable ZRAM for better memory usage
   zramSwap = {

--- a/hosts/iron-vm/configuration.nix
+++ b/hosts/iron-vm/configuration.nix
@@ -99,11 +99,15 @@
   };
   
   # Enable SSH for easy access to VM
+  # WARNING: Password authentication is enabled for ISOLATED TESTING ONLY
+  # This is a SECURITY RISK and should NEVER be used in production or on untrusted networks.
+  # For real deployments, use key-based authentication by setting PasswordAuthentication = false
+  # and configuring users.users.<name>.openssh.authorizedKeys instead.
   services.openssh = {
     enable = true;
     settings = {
       PermitRootLogin = "no";
-      PasswordAuthentication = true; # For easier VM testing
+      PasswordAuthentication = true; # TESTING ONLY - change to false for production!
     };
   };
   

--- a/hosts/iron-vm/configuration.nix
+++ b/hosts/iron-vm/configuration.nix
@@ -33,12 +33,8 @@
   services.thermald.enable = lib.mkForce false;
   powerManagement.enable = lib.mkDefault false;
   
-  # Enable virtio drivers for better performance
+  # Add VM-specific 9p modules for shared folders (virtio modules from hardware-configuration.nix)
   boot.initrd.availableKernelModules = [ 
-    "virtio_pci" 
-    "virtio_blk" 
-    "virtio_scsi" 
-    "virtio_net"
     "9p"
     "9pnet_virtio"
   ];

--- a/hosts/iron-vm/configuration.nix
+++ b/hosts/iron-vm/configuration.nix
@@ -42,10 +42,10 @@
   # Graphics for VM (use lightweight option)
   services.xserver.videoDrivers = lib.mkDefault [ "modesetting" ];
   
-  # Enable 3D acceleration for VMs (works with most hypervisors)
-  hardware.opengl = {
+  # Enable graphics acceleration for VMs (works with most hypervisors)
+  hardware.graphics = {
     enable = true;
-    driSupport = true;
+    enable32Bit = lib.mkDefault false;  # Disable 32-bit support to save resources in VM
   };
   
   # VM-friendly file system optimizations
@@ -94,9 +94,7 @@
   # programs.gamemode.enable = lib.mkForce false;
   
   # Network optimization for VMs
-  networking.interfaces = lib.mkDefault {
-    # VM typically uses NAT or bridged networking
-  };
+  # VMs typically use NAT or bridged networking configured by the hypervisor
   
   # Enable SSH for easy access to VM
   # WARNING: Password authentication is enabled for ISOLATED TESTING ONLY

--- a/hosts/iron-vm/configuration.nix
+++ b/hosts/iron-vm/configuration.nix
@@ -17,7 +17,6 @@
   
   # QEMU/KVM guest agent for better integration
   services.qemuGuest.enable = true;
-  services.spice-vdagentd.enable = true; # For SPICE display protocol
   
   # Optimize for virtual hardware
   boot.kernelParams = [

--- a/hosts/iron-vm/hardware-configuration.nix
+++ b/hosts/iron-vm/hardware-configuration.nix
@@ -1,0 +1,54 @@
+# Hardware configuration for iron-vm (Virtual Machine)
+# This file should be generated on the actual VM with:
+# sudo nixos-generate-config --show-hardware-config > hosts/iron-vm/hardware-configuration.nix
+
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  # VM-optimized hardware settings
+  boot.initrd.availableKernelModules = [ 
+    "ata_piix" 
+    "uhci_hcd" 
+    "virtio_pci" 
+    "virtio_scsi" 
+    "sd_mod" 
+    "sr_mod" 
+    "virtio_blk"
+    "virtio_net"
+  ];
+  
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ "kvm-amd" "kvm-intel" ]; # Support both AMD and Intel hosts
+  boot.extraModulePackages = [ ];
+
+  # File systems - PLACEHOLDER
+  # After installing NixOS in the VM, run:
+  #   sudo nixos-generate-config --show-hardware-config > hosts/iron-vm/hardware-configuration.nix
+  
+  # Example configuration (replace with actual after VM installation):
+  # fileSystems."/" = {
+  #   device = "/dev/disk/by-uuid/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX";
+  #   fsType = "ext4";
+  # };
+  
+  # fileSystems."/boot" = {
+  #   device = "/dev/disk/by-uuid/XXXX-XXXX";
+  #   fsType = "vfat";
+  # };
+  
+  # swapDevices = [ ];
+
+  # VM typically doesn't need these
+  networking.useDHCP = lib.mkDefault true;
+  
+  # CPU configuration
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  
+  # Enable CPU microcode updates (works for both AMD and Intel)
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+}

--- a/hosts/iron-vm/hardware-configuration.nix
+++ b/hosts/iron-vm/hardware-configuration.nix
@@ -47,8 +47,4 @@
   
   # CPU configuration
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
-  
-  # Enable CPU microcode updates (works for both AMD and Intel)
-  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
-  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 }


### PR DESCRIPTION
- Created VM-optimized configuration with virtio drivers
- Added QEMU guest agent and VMware tools support
- Enabled ZRAM for better memory usage
- Added SSH access for easy remote testing
- Included comprehensive README with setup instructions
- Optimized boot time and disabled unnecessary services for VMs
- Supports QEMU/KVM, VMware, and VirtualBox hypervisors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an iron-vm NixOS VM profile with VM guest tools (QEMU/VMware/SPICE), clipboard sharing, virtio drivers, faster boot, lightweight graphics/OpenGL, ZRAM-backed swap, SSH access (testing-friendly), serial console, DHCP networking placeholder, CPU microcode handling, and common diagnostics tools.

- **Documentation**
  - Added a comprehensive iron-vm README with VM creation steps (virt-manager/VMware/VirtualBox), specs, build/apply instructions, testing workflow, shared folders, performance tips, optional auto-login, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->